### PR TITLE
Cast abs calculation as integer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,7 +187,7 @@ void loop() {
   // millis() will overflow after round about 49 days
   // better calculate the absolute value of the difference
   if(!Screen_permanent_on){
-    if(Watch.screenState && abs(displayOffTimer - millis()) > displayTimeout){
+    if(Watch.screenState && abs(int(displayOffTimer - millis())) > displayTimeout){
       Watch.screenOff();
     }
   }


### PR DESCRIPTION
Build is failing for me...

```
src/main.cpp: In function 'void loop()':
src/main.cpp:186:59: error: call of overloaded 'abs(long unsigned int)' is ambiguous
  186 |     if(Watch.screenState && abs(displayOffTimer - millis()) > displayTimeout){
```

...wrapping the calculation as an INT seems to fix.